### PR TITLE
keel_load_theme_files reg as keel_load_theme_js

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -15,7 +15,7 @@
 		wp_enqueue_style( 'keel-theme-styles', get_template_directory_uri() . '/dist/css/main.css', null, null, 'all' );
 		wp_enqueue_script( 'keel-theme-scripts', get_template_directory_uri() . '/dist/js/main.js', null, null, true );
 	}
-	add_action('wp_enqueue_scripts', 'keel_load_theme_js');
+	add_action('wp_enqueue_scripts', 'keel_load_theme_files');
 
 
 


### PR DESCRIPTION
The function was recorded as being keel_load_theme_js which was created as keel_load_theme_files. I realized that in previous versions was keel_load_theme_js perhaps hence the confusion with versions of the function.

A little confusion was generating the error >> Warning: call_user_func_array() expects parameter 1 to be a valid callback, function 'keel_load_theme_js' not found or invalid function name in /home/adson/dev/sites/wordpress/wp-includes/plugin.php on line 496

I hope it helped. ;)
